### PR TITLE
G3 134: The geneweaver.core enumerations should use builtin IntEnum and StrEnum

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geneweaver-core"
-version = "0.8.0a1"
+version = "0.8.0a2"
 description = "The core of the Jax-Geneweaver Python library"
 authors = ["Jax Computational Sciences <cssc@jax.org>"]
 readme = "README.md"

--- a/src/geneweaver/core/enum.py
+++ b/src/geneweaver/core/enum.py
@@ -1,8 +1,8 @@
 """Enum classes for the GeneWeaver project."""
-from enum import Enum
+from enum import IntEnum, StrEnum
 
 
-class CurationAssignment(int, Enum):
+class CurationAssignment(IntEnum):
     """Enum for the different types of curation assignments."""
 
     UNASSIGNED = 1
@@ -12,7 +12,7 @@ class CurationAssignment(int, Enum):
     APPROVED = 5
 
 
-class GenesetScoreTypeStr(str, Enum):
+class GenesetScoreTypeStr(StrEnum):
     """Enum for the different types of geneset scores."""
 
     P_VALUE = "p-value"
@@ -26,7 +26,7 @@ class GenesetScoreTypeStr(str, Enum):
         return "-".join(part.capitalize() for part in self.name.split("_"))
 
 
-class ScoreType(int, Enum):
+class ScoreType(IntEnum):
     """Integer based Enum for the different types of geneset scores."""
 
     P_VALUE = 1
@@ -40,21 +40,21 @@ class ScoreType(int, Enum):
         return "-".join(part.capitalize() for part in self.name.split("_"))
 
 
-class GenesetAccess(str, Enum):
+class GenesetAccess(StrEnum):
     """Enum for the different types of geneset access."""
 
     PRIVATE = "private"
     PUBLIC = "public"
 
 
-class AnnotationType(str, Enum):
+class AnnotationType(StrEnum):
     """Enum for the different types of annotations."""
 
     MONARCH = "monarch"
     NCBO = "ncbo"
 
 
-class AdminLevel(int, Enum):
+class AdminLevel(IntEnum):
     """Enum for the different levels of admin access."""
 
     NORMAL_USER = 0
@@ -63,7 +63,7 @@ class AdminLevel(int, Enum):
     ADMIN_WITH_DEBUG = 3
 
 
-class Species(int, Enum):
+class Species(IntEnum):
     """Species enum to match Geneweaver database."""
 
     ALL = 0
@@ -83,7 +83,7 @@ class Species(int, Enum):
         return self.name.replace("_", " ").capitalize()
 
 
-class GeneIdentifier(int, Enum):
+class GeneIdentifier(IntEnum):
     """Gene Identifier types to match Geneweaver database."""
 
     ENTREZ = 1
@@ -110,7 +110,7 @@ class GeneIdentifier(int, Enum):
         return self.name
 
 
-class Microarray(int, Enum):
+class Microarray(IntEnum):
     """Microarray types (does not match geneweaver database)."""
 
     AFFYMETRIX_C_ELEGANS_GENOME_ARRAY = 100

--- a/src/geneweaver/core/enum.py
+++ b/src/geneweaver/core/enum.py
@@ -1,5 +1,5 @@
 """Enum classes for the GeneWeaver project."""
-from enum import IntEnum, Enum
+from enum import Enum, IntEnum
 
 
 class CurationAssignment(IntEnum):
@@ -12,7 +12,7 @@ class CurationAssignment(IntEnum):
     APPROVED = 5
 
 
-class GenesetScoreTypeStr(Enum):
+class GenesetScoreTypeStr(str, Enum):
     """Enum for the different types of geneset scores."""
 
     P_VALUE = "p-value"
@@ -40,14 +40,14 @@ class ScoreType(IntEnum):
         return "-".join(part.capitalize() for part in self.name.split("_"))
 
 
-class GenesetAccess(Enum):
+class GenesetAccess(str, Enum):
     """Enum for the different types of geneset access."""
 
     PRIVATE = "private"
     PUBLIC = "public"
 
 
-class AnnotationType(Enum):
+class AnnotationType(str, Enum):
     """Enum for the different types of annotations."""
 
     MONARCH = "monarch"

--- a/src/geneweaver/core/enum.py
+++ b/src/geneweaver/core/enum.py
@@ -1,5 +1,5 @@
 """Enum classes for the GeneWeaver project."""
-from enum import IntEnum, StrEnum
+from enum import IntEnum, Enum
 
 
 class CurationAssignment(IntEnum):
@@ -12,7 +12,7 @@ class CurationAssignment(IntEnum):
     APPROVED = 5
 
 
-class GenesetScoreTypeStr(StrEnum):
+class GenesetScoreTypeStr(Enum):
     """Enum for the different types of geneset scores."""
 
     P_VALUE = "p-value"
@@ -40,14 +40,14 @@ class ScoreType(IntEnum):
         return "-".join(part.capitalize() for part in self.name.split("_"))
 
 
-class GenesetAccess(StrEnum):
+class GenesetAccess(Enum):
     """Enum for the different types of geneset access."""
 
     PRIVATE = "private"
     PUBLIC = "public"
 
 
-class AnnotationType(StrEnum):
+class AnnotationType(Enum):
     """Enum for the different types of annotations."""
 
     MONARCH = "monarch"

--- a/tests/unit/test_enum.py
+++ b/tests/unit/test_enum.py
@@ -1,10 +1,16 @@
 """Test the enum module."""
+from enum import Enum, IntEnum
+
 import pytest
 from geneweaver.core.enum import (
+    AdminLevel,
     CurationAssignment,
+    GeneIdentifier,
     GenesetAccess,
     GenesetScoreTypeStr,
+    Microarray,
     ScoreType,
+    Species,
 )
 
 
@@ -45,7 +51,7 @@ def test_curation_assignment_from_int(
 )
 def test_geneset_access(attribute: str, expected: str) -> None:
     """Test the GenesetAccess enum."""
-    assert getattr(GenesetAccess, attribute) == expected
+    assert getattr(GenesetAccess, attribute).value == expected
 
 
 def test_geneset_access_from_string() -> None:
@@ -88,3 +94,14 @@ def test_geneset_score_type_str_from_string() -> None:
     assert GenesetScoreTypeStr("binary") == GenesetScoreTypeStr.BINARY
     assert GenesetScoreTypeStr("correlation") == GenesetScoreTypeStr.CORRELATION
     assert GenesetScoreTypeStr("effect") == GenesetScoreTypeStr.EFFECT
+
+
+@pytest.mark.parametrize(
+    "enum_class",
+    [CurationAssignment, ScoreType, AdminLevel, Species, GeneIdentifier, Microarray],
+)
+def test_is_int_enum(enum_class):
+    """Test that Integer Enums are defined as IntEnum."""
+    assert issubclass(enum_class, int)
+    assert issubclass(enum_class, Enum)
+    assert issubclass(enum_class, IntEnum)


### PR DESCRIPTION
Switching to IntEnum for Integer based enum definitions to allow usage in FastAPI type annotations.