### PR TITLE
Ignore None values when rendering geneset metadata

### DIFF
--- a/src/geneweaver/core/render/batch.py
+++ b/src/geneweaver/core/render/batch.py
@@ -38,7 +38,7 @@ def format_geneset_metadata(geneset: BatchUploadGeneset) -> str:
         (
             f"{INV_CHAR_MAP[key] if key in INV_CHAR_MAP else key} {str(value)}"
             for key, value in geneset
-            if key != "values"
+            if key != "values" and value is not None
         )
     )
     data_str += "\n\n"

--- a/tests/unit/render/batch/test_format_genest_metadata.py
+++ b/tests/unit/render/batch/test_format_genest_metadata.py
@@ -11,6 +11,6 @@ def test_format_geneset_metadata_standard(mock_batch_upload_geneset_all_combinat
     # Assert that the output is a string and has the expected structure
     assert isinstance(formatted_metadata, str)
     # Additional assertions can be made based on the specific format of the metadata
-    assert formatted_metadata.count("\n") == 10
-    for char in ["!", "@", "%", "P", "A", "T", ":", "=", "+"]:
+    assert formatted_metadata.count("\n") == 8
+    for char in ["!", "@", "%", "A", ":", "=", "+"]:
         assert char in formatted_metadata

--- a/tests/unit/render/conftest.py
+++ b/tests/unit/render/conftest.py
@@ -128,6 +128,7 @@ def mock_batch_upload_geneset_all_combinations(
         score=geneset_score_type,
         species=species,
         gene_id_type=any_gene_identifier,
+        private=True,
         abbreviation="MOCK",
         name="Mock Geneset",
         description="Mock geneset for testing.",


### PR DESCRIPTION
Related Ticket: [G3-91](https://jacksonlaboratory.atlassian.net/browse/G3-91)

This changes the batch renderer to ignore None values when rendering the metadata header.